### PR TITLE
Rename surface view

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/SurfaceViewPreview.java
+++ b/android/src/main/java/com/google/android/cameraview/SurfaceViewPreview.java
@@ -31,8 +31,8 @@ class SurfaceViewPreview extends PreviewImpl {
     final SurfaceView mSurfaceView;
 
     SurfaceViewPreview(Context context, ViewGroup parent) {
-        final View view = View.inflate(context, R.layout.surface_view, parent);
-        mSurfaceView = (SurfaceView) view.findViewById(R.id.surface_view);
+        final View view = View.inflate(context, R.layout.rn_surface_view, parent);
+        mSurfaceView = (SurfaceView) view.findViewById(R.id.rn_surface_view);
         final SurfaceHolder holder = mSurfaceView.getHolder();
         //noinspection deprecation
         holder.setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);

--- a/android/src/main/res/layout/rn_surface_view.xml
+++ b/android/src/main/res/layout/rn_surface_view.xml
@@ -14,7 +14,7 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
 
     <SurfaceView
-        android:id="@+id/surface_view"
+        android:id="@+id/rn_surface_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"


### PR DESCRIPTION
Rename `surface_view` file and id to avoid name clash with Sabbatic SDK